### PR TITLE
[task_004]:BinanceOrder APIのCOIN-M取引機能追加（BTCのみ）

### DIFF
--- a/functions/src/modules/binanceOrder.ts
+++ b/functions/src/modules/binanceOrder.ts
@@ -1,8 +1,12 @@
+// modules
 import { logger, Request, Response } from 'firebase-functions'
-import { BinanceOrderFunction, AccessSecret } from '../types/modules/binanceOrder'
 import CcxtWrapper from '../utils/ccxtWrapper'
-import { BinanceOrderResponse } from '../types/response/orderResponse'
 import { SecretManagerServiceClient } from '@google-cloud/secret-manager'
+import CryptoUtils from '../utils/cryptoUtils'
+// types
+import { BinanceOrderFunction, AccessSecret } from '../types/modules/binanceOrder'
+import { BinanceOrderResponse } from '../types/response/orderResponse'
+import { ExchangeType, ExchangeName } from '../types/utils/ccxtWrapper'
 
 export const BTC_SHORT_SL_WIDTH = 1.012 // BTC shortポジションの損切幅 比率
 export const BTC_SHORT_TP_WIDTH = 0.98 // BTC shortポジションの利確幅 比率
@@ -16,17 +20,21 @@ export const BTC_LONG_LIMIT_WIDTH = 0.9999 // ロング指値幅 比率
 export const BTC_SHORT_LIMIT_WIDTH = 1.00006 // ショート指値幅 比率
 export const ALT_LONG_LIMIT_WIDTH = 0.9996 // ロング指値幅 比率
 export const ALT_SHORT_LIMIT_WIDTH = 1.0001 // ショート指値幅 比率
-export const BALANCE_RATE = 0.8 // 使用する証拠金の比率
-export const BTC_LEVERAGE = 4 // BTC注文時のレバレッジ
-export const ALT_LEVERAGE = 2.7 // ALT注文時のレバレッジ
+export const BTC_LEVERAGE = 3.2 // BTC注文時のレバレッジ
+export const ALT_LEVERAGE = 1.9 // ALT注文時のレバレッジ
 export const NAME_TAG_BINANCE_KEY = 'binance_api_key'
 export const NAME_TAG_BINANCE_SECRET = 'binance_secret'
+export const BTC_USD_MINIMUM_AMOUNT = 100 // COIN-M 先物の注文最小値(USD値)
 
 /* eslint @typescript-eslint/no-explicit-any: 0 */
 const binanceOrder: BinanceOrderFunction = async (request: Request, response: Response): Promise<Response> => {
     const body = request.body
     if (!body.strategy || body.strategy.order.comment !== 'entry') {
         return response.send('not entry request')
+    }
+
+    if (!CryptoUtils.isBTC(body.symbol) && !CryptoUtils.isUSDT(body.marginCoin)) {
+        return response.status(400).send('Bad request. Altcoin cannot be used for margin')
     }
 
     const client = new SecretManagerServiceClient()
@@ -51,10 +59,10 @@ const binanceOrder: BinanceOrderFunction = async (request: Request, response: Re
 
     const apiKey = secrets.find((secret) => secret.name === NAME_TAG_BINANCE_KEY)
     const apiSecret = secrets.find((secret) => secret.name === NAME_TAG_BINANCE_SECRET)
-    const ccxt = new CcxtWrapper(apiKey!.data, apiSecret!.data, 'binance')
+    const ccxt = new CcxtWrapper(apiKey!.data, apiSecret!.data, body.type, ExchangeName.BINANCE)
     let availableBalance = 0
     try {
-        availableBalance = (await ccxt.getAvailableBalance('USDT')) * BALANCE_RATE
+        availableBalance = await ccxt.getAvailableBalance(body.marginCoin)
     } catch (error) {
         logger.warn(error)
         return response.status(500).send('getAvailableBalance error')
@@ -65,12 +73,12 @@ const binanceOrder: BinanceOrderFunction = async (request: Request, response: Re
     }
 
     const currentPrice = Number(body.strategy.order.price)
-    const isLong = ccxt.isLong(body.strategy.order.action)
+    const isLong = CryptoUtils.isLong(body.strategy.order.action)
     let stopLoss = 0
     let takeProfit = 0
     let amount: number = availableBalance
     let limitPrice: number = currentPrice
-    if (ccxt.isBTC(body.symbol)) {
+    if (CryptoUtils.isBTC(body.symbol)) {
         if (isLong) {
             // BTCロング
             stopLoss = BTC_LONG_SL_WIDTH
@@ -82,7 +90,16 @@ const binanceOrder: BinanceOrderFunction = async (request: Request, response: Re
             takeProfit = BTC_SHORT_TP_WIDTH
             limitPrice = limitPrice * BTC_SHORT_LIMIT_WIDTH
         }
-        amount = (availableBalance / currentPrice) * BTC_LEVERAGE
+
+        if (body.type === ExchangeType.FUTURE) {
+            // USD-S-M先物
+            amount = (availableBalance / currentPrice) * BTC_LEVERAGE
+        } else {
+            // COIN-M先物
+            let minimumUnit = BTC_USD_MINIMUM_AMOUNT / currentPrice
+            minimumUnit = Math.floor(minimumUnit * 100000) / 100000 // 小数点第5位未満を切り捨て
+            amount = Math.floor(availableBalance / minimumUnit) * BTC_LEVERAGE
+        }
     } else {
         if (isLong) {
             // ALTロング

--- a/functions/src/types/request/tradingviewRequest.d.ts
+++ b/functions/src/types/request/tradingviewRequest.d.ts
@@ -2,6 +2,8 @@ export type TradingviewRequest = {
     botName: string // botの名前
     symbol: string // 手動設定したティッカー (tradingviewのティッカーが使えない時用)
     ticker: string // tradingviewのティッカー
+    type: 'delivery' | 'future' | 'margin' | 'spot' // 交換タイプ
+    marginCoin: 'BTC' | 'USDT' // 証拠金として使用する通貨
     strategy: Strategy
 }
 

--- a/functions/src/types/utils/ccxtWrapper.d.ts
+++ b/functions/src/types/utils/ccxtWrapper.d.ts
@@ -26,6 +26,33 @@ export type OrderParams = {
     params?: Params
 }
 
+export const enum ExchangeType {
+    DELIVERY = 'delivery',
+    FUTURE = 'future',
+    MARGIN = 'margin',
+    SPOT = 'spot'
+}
+
+export const enum ExchangeName {
+    BINANCE = 'binance',
+    BYBIT = 'bybit'
+}
+
+/**
+ * STOP = stop指値注文
+ * STOP_MARKET = stop成行注文
+ * TAKE_PROFIT = takeprofit指値注文
+ * TAKE_PROFIT_MARKET = takeprofit成行注文
+ **/
+export const enum OrderType {
+    MARKET = 'MARKET',
+    LIMIT = 'LIMIT',
+    STOP = 'STOP',
+    STOP_MARKET = 'STOP_MARKET',
+    TAKE_PROFIT = 'TAKE_PROFIT',
+    TAKE_PROFIT_MARKET = 'TAKE_PROFIT_MARKET'
+}
+
 // createOrderのparamsオプション
 export type BinanceOrderParams = {
     reduceOnly?: boolean // trueならreduceOnly注文
@@ -38,14 +65,6 @@ export type BinanceOrderParams = {
     positionSide?: string
     activatePrice?: number
 }
-
-/**
- * STOP = stop指値注文
- * STOP_MARKET = stop成行注文
- * TAKE_PROFIT = takeprofit指値注文
- * TAKE_PROFIT_MARKET = takeprofit成行注文
- **/
-export type BinanceOrderTypes = 'MARKET' | 'LIMIT' | 'STOP' | 'STOP_MARKET' | 'TAKE_PROFIT' | 'TAKE_PROFIT_MARKET'
 
 export type Side = 'sell' | 'buy'
 

--- a/functions/src/utils/cryptoUtils.ts
+++ b/functions/src/utils/cryptoUtils.ts
@@ -1,0 +1,18 @@
+import { Side } from '../types/utils/ccxtWrapper'
+
+export default class CryptoUtils {
+    static isLong(side: Side): boolean {
+        if (side === 'sell') {
+            return false
+        }
+        return true
+    }
+
+    static isBTC(symbol: string): boolean {
+        return Boolean(symbol.match('BTC'))
+    }
+
+    static isUSDT(symbol: string): boolean {
+        return Boolean(symbol.match('USDT'))
+    }
+}

--- a/functions/tests/modules/binanceOrder.test.ts
+++ b/functions/tests/modules/binanceOrder.test.ts
@@ -10,8 +10,6 @@ const getAvailableBalanceSpyOn = jest.spyOn(CcxtWrapper.prototype, 'getAvailable
 const newOrderSpyOn = jest.spyOn(CcxtWrapper.prototype, 'newOrder')
 const stopOrderSpyOn = jest.spyOn(CcxtWrapper.prototype, 'stopOrder')
 const takeProfitOrderSpyOn = jest.spyOn(CcxtWrapper.prototype, 'takeProfitOrder')
-const isBTCSpyOn = jest.spyOn(CcxtWrapper.prototype, 'isBTC')
-const isLongSpyOn = jest.spyOn(CcxtWrapper.prototype, 'isLong')
 const createTpSlOrderPrices = jest.spyOn(CcxtWrapper.prototype, 'createTpSlOrderPrices')
 const accessSecretVersionSpyOn = jest.spyOn(SecretManagerServiceClient.prototype, 'accessSecretVersion')
 
@@ -36,8 +34,8 @@ describe('binanceOrder', () => {
             data: Buffer.from('test_key')
         },
     },
-        {},
-        {}
+    {},
+    {}
     ]
     const accessSecret = [{
         name: BinanceOrder.NAME_TAG_BINANCE_SECRET,
@@ -45,20 +43,11 @@ describe('binanceOrder', () => {
             data: Buffer.from('test_secret')
         }
     },
-        {},
-        {}
+    {},
+    {}
     ]
 
     beforeEach(() => {
-        isBTCSpyOn.mockImplementation((symbol: string): boolean => {
-            return Boolean(symbol.match('BTC'))
-        })
-        isLongSpyOn.mockImplementation((side: Side): boolean => {
-            if (side === 'sell') {
-                return false
-            }
-            return true
-        })
         createTpSlOrderPrices.mockImplementation(
             (orderInfo: any, takeProfit: number, stopLoss: number): TpAndSl => {
                 const side = orderInfo.side === 'buy' ? 'sell' : 'buy'
@@ -74,18 +63,18 @@ describe('binanceOrder', () => {
         newOrderSpyOn.mockRestore()
         stopOrderSpyOn.mockRestore()
         takeProfitOrderSpyOn.mockRestore()
-        isBTCSpyOn.mockRestore()
-        isLongSpyOn.mockRestore()
         createTpSlOrderPrices.mockRestore()
         accessSecretVersionSpyOn.mockRestore()
     })
 
-    test('BTC ロング', async () => {
+    test('BTC future ロング', async () => {
         const req = {
             body: {
                 botName: 'test bot',
                 ticker: 'BTCUSDTPERP',
                 symbol: 'BTCUSDT',
+                type: 'future',
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '45000',
@@ -111,10 +100,9 @@ describe('binanceOrder', () => {
                 }
             }
         )
-        const balance = availableBalance * BinanceOrder.BALANCE_RATE
         const currentPrice = Number(req.body.strategy.order.price)
         const expectLimitPrice = currentPrice * BinanceOrder.BTC_LONG_LIMIT_WIDTH
-        const expectAmount = (balance / currentPrice) * BinanceOrder.BTC_LEVERAGE
+        const expectAmount = (availableBalance / currentPrice) * BinanceOrder.BTC_LEVERAGE
         const newOrderResponse = {
             symbol: req.body.symbol,
             side: req.body.strategy.order.action,
@@ -134,6 +122,7 @@ describe('binanceOrder', () => {
         })
 
         const result = await binanceOrder(req, res)
+        expect(getAvailableBalanceSpyOn).toHaveBeenCalledWith(req.body.marginCoin)
         expect(newOrderSpyOn).toHaveBeenCalledWith(
             req.body.symbol,
             req.body.strategy.order.action,
@@ -145,12 +134,83 @@ describe('binanceOrder', () => {
         expect(result).toBe('order success')
     })
 
-    test('BTC ショート', async () => {
+    test('BTC delivery ロング', async () => {
+        const req = {
+            body: {
+                botName: 'test bot',
+                ticker: 'BTCPERP',
+                symbol: 'BTCUSD_PERP',
+                type: 'delivery',
+                marginCoin: 'BTC',
+                strategy: {
+                    order: {
+                        price: '45000',
+                        action: 'buy',
+                        contracts: '1',
+                        id: 'long entry id',
+                        comment: 'entry'
+                    },
+                    marketPosition: 'long',
+                    market_position_size: '0.01',
+                    positionSize: '-0.01'
+                }
+            }
+        } as Request
+        getAvailableBalanceSpyOn.mockResolvedValue(availableBalance)
+        newOrderSpyOn.mockImplementation(
+            async (symbol: string, side: Side, amount: number, limitPrice: number): Promise<any> => {
+                return {
+                    symbol,
+                    side,
+                    amount,
+                    price: limitPrice
+                }
+            }
+        )
+        const currentPrice = Number(req.body.strategy.order.price)
+        const expectLimitPrice = currentPrice * BinanceOrder.BTC_LONG_LIMIT_WIDTH
+        let minimumUnit = BinanceOrder.BTC_USD_MINIMUM_AMOUNT / currentPrice
+        minimumUnit = Math.floor(minimumUnit * 100000) / 100000
+        const expectAmount = Math.floor(availableBalance / minimumUnit) * BinanceOrder.BTC_LEVERAGE
+        const newOrderResponse = {
+            symbol: req.body.symbol,
+            side: req.body.strategy.order.action,
+            amount: expectAmount,
+            price: expectLimitPrice
+        }
+        const expectPrices = {
+            side: 'sell',
+            stopLossPrice: expectLimitPrice * BinanceOrder.BTC_LONG_SL_WIDTH,
+            takeProfitPrice: expectLimitPrice * BinanceOrder.BTC_LONG_TP_WIDTH
+        }
+
+        accessSecretVersionSpyOn.mockImplementationOnce(async () => {
+            return accessSecretKey
+        }).mockImplementationOnce(async () => {
+            return accessSecret
+        })
+
+        const result = await binanceOrder(req, res)
+        expect(getAvailableBalanceSpyOn).toHaveBeenCalledWith(req.body.marginCoin)
+        expect(newOrderSpyOn).toHaveBeenCalledWith(
+            req.body.symbol,
+            req.body.strategy.order.action,
+            expectAmount,
+            expectLimitPrice
+        )
+        expect(stopOrderSpyOn).toHaveBeenCalledWith(newOrderResponse, expectPrices)
+        expect(takeProfitOrderSpyOn).toHaveBeenCalledWith(newOrderResponse, expectPrices)
+        expect(result).toBe('order success')
+    })
+
+    test('BTC future ショート', async () => {
         const req = {
             body: {
                 botName: 'test bot',
                 ticker: 'BTCUSDTPERP',
                 symbol: 'BTCUSDT',
+                type: 'future',
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '45000',
@@ -176,10 +236,9 @@ describe('binanceOrder', () => {
                 }
             }
         )
-        const balance = availableBalance * BinanceOrder.BALANCE_RATE
         const currentPrice = Number(req.body.strategy.order.price)
         const expectLimitPrice = currentPrice * BinanceOrder.BTC_SHORT_LIMIT_WIDTH
-        const expectAmount = (balance / currentPrice) * BinanceOrder.BTC_LEVERAGE
+        const expectAmount = (availableBalance / currentPrice) * BinanceOrder.BTC_LEVERAGE
         const newOrderResponse = {
             symbol: req.body.symbol,
             side: req.body.strategy.order.action,
@@ -197,6 +256,74 @@ describe('binanceOrder', () => {
             return accessSecret
         })
         const result = await binanceOrder(req, res)
+        expect(getAvailableBalanceSpyOn).toHaveBeenCalledWith(req.body.marginCoin)
+        expect(newOrderSpyOn).toHaveBeenCalledWith(
+            req.body.symbol,
+            req.body.strategy.order.action,
+            expectAmount,
+            expectLimitPrice
+        )
+        expect(stopOrderSpyOn).toHaveBeenCalledWith(newOrderResponse, expectPrices)
+        expect(takeProfitOrderSpyOn).toHaveBeenCalledWith(newOrderResponse, expectPrices)
+        expect(result).toBe('order success')
+    })
+
+    test('BTC delivery ショート', async () => {
+        const req = {
+            body: {
+                botName: 'test bot',
+                ticker: 'BTCUSDTPERP',
+                symbol: 'BTCUSDT',
+                type: 'delivery',
+                marginCoin: 'USDT',
+                strategy: {
+                    order: {
+                        price: '45000',
+                        action: 'sell',
+                        contracts: '1',
+                        id: 'sell entry id',
+                        comment: 'entry'
+                    },
+                    marketPosition: 'short',
+                    market_position_size: '0.01',
+                    positionSize: '-0.01'
+                }
+            }
+        } as Request
+        getAvailableBalanceSpyOn.mockResolvedValue(availableBalance)
+        newOrderSpyOn.mockImplementation(
+            async (symbol: string, side: Side, amount: number, limitPrice: number): Promise<any> => {
+                return {
+                    symbol,
+                    side,
+                    amount,
+                    price: limitPrice
+                }
+            }
+        )
+        const currentPrice = Number(req.body.strategy.order.price)
+        const expectLimitPrice = currentPrice * BinanceOrder.BTC_SHORT_LIMIT_WIDTH
+        let minimumUnit = BinanceOrder.BTC_USD_MINIMUM_AMOUNT / currentPrice
+        minimumUnit = Math.floor(minimumUnit * 100000) / 100000
+        const expectAmount = Math.floor(availableBalance / minimumUnit) * BinanceOrder.BTC_LEVERAGE
+        const newOrderResponse = {
+            symbol: req.body.symbol,
+            side: req.body.strategy.order.action,
+            amount: expectAmount,
+            price: expectLimitPrice
+        }
+        const expectPrices = {
+            side: 'buy',
+            stopLossPrice: expectLimitPrice * BinanceOrder.BTC_SHORT_SL_WIDTH,
+            takeProfitPrice: expectLimitPrice * BinanceOrder.BTC_SHORT_TP_WIDTH
+        }
+        accessSecretVersionSpyOn.mockImplementationOnce(async () => {
+            return accessSecretKey
+        }).mockImplementationOnce(async () => {
+            return accessSecret
+        })
+        const result = await binanceOrder(req, res)
+        expect(getAvailableBalanceSpyOn).toHaveBeenCalledWith(req.body.marginCoin)
         expect(newOrderSpyOn).toHaveBeenCalledWith(
             req.body.symbol,
             req.body.strategy.order.action,
@@ -214,6 +341,8 @@ describe('binanceOrder', () => {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: 'future',
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -239,10 +368,9 @@ describe('binanceOrder', () => {
                 }
             }
         )
-        const balance = availableBalance * BinanceOrder.BALANCE_RATE
         const currentPrice = Number(req.body.strategy.order.price)
         const expectLimitPrice = currentPrice * BinanceOrder.ALT_LONG_LIMIT_WIDTH
-        const expectAmount = (balance / currentPrice) * BinanceOrder.ALT_LEVERAGE
+        const expectAmount = (availableBalance / currentPrice) * BinanceOrder.ALT_LEVERAGE
         const newOrderResponse = {
             symbol: req.body.symbol,
             side: req.body.strategy.order.action,
@@ -260,6 +388,7 @@ describe('binanceOrder', () => {
             return accessSecret
         })
         const result = await binanceOrder(req, res)
+        expect(getAvailableBalanceSpyOn).toHaveBeenCalledWith(req.body.marginCoin)
         expect(newOrderSpyOn).toHaveBeenCalledWith(
             req.body.symbol,
             req.body.strategy.order.action,
@@ -277,6 +406,8 @@ describe('binanceOrder', () => {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: 'future',
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -302,10 +433,9 @@ describe('binanceOrder', () => {
                 }
             }
         )
-        const balance = availableBalance * BinanceOrder.BALANCE_RATE
         const currentPrice = Number(req.body.strategy.order.price)
         const expectLimitPrice = currentPrice * BinanceOrder.ALT_SHORT_LIMIT_WIDTH
-        const expectAmount = (balance / currentPrice) * BinanceOrder.ALT_LEVERAGE
+        const expectAmount = (availableBalance / currentPrice) * BinanceOrder.ALT_LEVERAGE
         const newOrderResponse = {
             symbol: req.body.symbol,
             side: req.body.strategy.order.action,
@@ -340,6 +470,8 @@ describe('binanceOrder', () => {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: "future",
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -358,12 +490,69 @@ describe('binanceOrder', () => {
         expect(result).toBe('not entry request')
     })
 
+    test('body.marginCoin(証拠金)がアルトコイン', async () => {
+        const req = {
+            body: {
+                botName: 'test bot',
+                ticker: 'XRPPERP',
+                symbol: 'XRPUSD_PERP',
+                type: "delivery",
+                marginCoin: 'XRP',
+                strategy: {
+                    order: {
+                        price: '1.5',
+                        action: 'sell',
+                        contracts: '1',
+                        id: 'sell entry id',
+                        comment: 'entry'
+                    },
+                    marketPosition: 'short',
+                    market_position_size: '0.01',
+                    positionSize: '-0.01'
+                }
+            }
+        } as Request
+        const result = await binanceOrder(req, res)
+        expect(result).toBe('Bad request. Altcoin cannot be used for margin')
+    })
+
+    test('API key取得失敗', async () => {
+        const req = {
+            body: {
+                botName: 'test bot',
+                ticker: 'XRPUSDTPERP',
+                symbol: 'XRPUSDT',
+                type: "future",
+                marginCoin: 'USDT',
+                strategy: {
+                    order: {
+                        price: '1.5',
+                        action: 'sell',
+                        contracts: '1',
+                        id: 'sell entry id',
+                        comment: 'entry'
+                    },
+                    marketPosition: 'short',
+                    market_position_size: '0.01',
+                    positionSize: '-0.01'
+                }
+            }
+        } as Request
+        accessSecretVersionSpyOn.mockImplementationOnce(async () => {
+            throw new Error('access secret version error')
+        })
+        const result = await binanceOrder(req, res)
+        expect(result).toBe('get accessSecretVersion error')
+    })
+
     test('availableBalance取得失敗', async () => {
         const req = {
             body: {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: "future",
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -406,6 +595,8 @@ describe('binanceOrder', () => {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: "future",
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -436,6 +627,8 @@ describe('binanceOrder', () => {
                 botName: 'test bot',
                 ticker: 'XRPUSDTPERP',
                 symbol: 'XRPUSDT',
+                type: "future",
+                marginCoin: 'USDT',
                 strategy: {
                     order: {
                         price: '1.5',
@@ -459,10 +652,9 @@ describe('binanceOrder', () => {
         }).mockImplementationOnce(async () => {
             return accessSecret
         })
-        const balance = availableBalance * BinanceOrder.BALANCE_RATE
         const currentPrice = Number(req.body.strategy.order.price)
         const expectLimitPrice = currentPrice * BinanceOrder.ALT_SHORT_LIMIT_WIDTH
-        const expectAmount = (balance / currentPrice) * BinanceOrder.ALT_LEVERAGE
+        const expectAmount = (availableBalance / currentPrice) * BinanceOrder.ALT_LEVERAGE
         const result = await binanceOrder(req, res)
         expect(newOrderSpyOn).toHaveBeenCalledWith(
             req.body.symbol,

--- a/functions/tests/utils/ccxtWrapper.test.ts
+++ b/functions/tests/utils/ccxtWrapper.test.ts
@@ -1,12 +1,9 @@
 import CcxtWrapper from '../../src/utils/ccxtWrapper'
-import { TpAndSl } from '../../src/types/utils/ccxtWrapper'
+import { TpAndSl, ExchangeType } from '../../src/types/utils/ccxtWrapper'
 import { binance, Order } from 'ccxt'
 jest.mock('ccxt')
 
 describe('ccxtWrapper', () => {
-
-
-
     describe('Binance', () => {
         const exchangeName = 'binance'
         const testBalanceSymbol = 'USDT'
@@ -41,13 +38,13 @@ describe('ccxtWrapper', () => {
                 },
             }
             fetchBalanceMock.mockResolvedValue(balances)
-            const ccxtWrapper = new CcxtWrapper(apiKey, secret)
+            const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY)
             const result = await ccxtWrapper.getAvailableBalance(testBalanceSymbol)
             expect(result).toBe(Number(balances.info.assets[1].availableBalance))
         })
 
         test('newOrder', async () => {
-            const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
+            const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY, exchangeName)
             const limitPrice = 10000
             const orderResult: Order = {
                 "price": 10000,
@@ -102,7 +99,7 @@ describe('ccxtWrapper', () => {
         })
 
         test('stopOrder', async () => {
-            const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
+            const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY, exchangeName)
             const prices: TpAndSl = {
                 side: 'buy',
                 stopLossPrice: 10100,
@@ -162,7 +159,7 @@ describe('ccxtWrapper', () => {
         })
 
         test('takeProfitOrder', async () => {
-            const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
+            const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY, exchangeName)
             const prices: TpAndSl = {
                 side: 'buy',
                 stopLossPrice: 10100,
@@ -270,7 +267,7 @@ describe('ccxtWrapper', () => {
                     "amount": 0.028,
                     "lastTradeTimestamp": 1650819352434,
                 }
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
+                const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY, exchangeName)
                 const takeProfit = 0.98
                 const stopLoss = 1.02
                 const result = ccxtWrapper.createTpSlOrderPrices(orderResult, takeProfit, stopLoss)
@@ -327,37 +324,13 @@ describe('ccxtWrapper', () => {
                     "amount": 0.028,
                     "lastTradeTimestamp": 1650819352434,
                 }
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
+                const ccxtWrapper = new CcxtWrapper(apiKey, secret, ExchangeType.DELIVERY, exchangeName)
                 const takeProfit = 0.98
                 const stopLoss = 1.02
                 const result = ccxtWrapper.createTpSlOrderPrices(orderResult, takeProfit, stopLoss)
                 expect(result).toHaveProperty('side', 'buy')
                 expect(result).toHaveProperty('stopLossPrice', (orderResult.price * stopLoss))
                 expect(result).toHaveProperty('takeProfitPrice', (orderResult.price * takeProfit))
-            })
-        })
-    
-        describe('isBTC', () => {
-            test('symbol = BTC', () => {
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
-                expect(ccxtWrapper.isBTC('BTCUSDT')).toBeTruthy()
-            })
-    
-            test('symbol = XRP', () => {
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
-                expect(ccxtWrapper.isBTC('XRPSDT')).toBeFalsy()
-            })
-        })
-    
-        describe('isLong', () => {
-            test('side = sell', () => {
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
-                expect(ccxtWrapper.isLong('sell')).toBeFalsy()
-            })
-    
-            test('side = buy', () => {
-                const ccxtWrapper = new CcxtWrapper(apiKey, secret, exchangeName)
-                expect(ccxtWrapper.isLong('buy')).toBeTruthy()
             })
         })
     })

--- a/functions/tests/utils/cryptoUtils.test.ts
+++ b/functions/tests/utils/cryptoUtils.test.ts
@@ -1,0 +1,33 @@
+import CryptoUtils from '../../src/utils/cryptoUtils'
+
+describe('CryptoUtils', () => {
+    describe('isBTC', () => {
+        test('symbol = BTC', () => {
+            expect(CryptoUtils.isBTC('BTCUSDT')).toBeTruthy()
+        })
+
+        test('symbol = XRP', () => {
+            expect(CryptoUtils.isBTC('XRPSDT')).toBeFalsy()
+        })
+    })
+    
+    describe('isLong', () => {
+        test('side = sell', () => {
+            expect(CryptoUtils.isLong('sell')).toBeFalsy()
+        })
+
+        test('side = buy', () => {
+            expect(CryptoUtils.isLong('buy')).toBeTruthy()
+        })
+    })
+
+    describe('isLong', () => {
+        test('symbol = ETH', () => {
+            expect(CryptoUtils.isUSDT('ETH')).toBeFalsy()
+        })
+
+        test('symbol = USDT', () => {
+            expect(CryptoUtils.isUSDT('USDT')).toBeTruthy()
+        })
+    })
+})


### PR DESCRIPTION
# BinanceでBTCを証拠金に取引する（COIN-M）機能追加

## 変更点
- request.body.marginCoinの値でアカウントの利用可能な証拠金を取得
- request.body.typeの値に応じてBTCの取引をUSDS－M、COIN-Ｍに切り替える
request.body.type: 'future' = USDS-M
request.body.type: 'delyvery' = COIN-M
- COIN-Ｍ取引のロット計算分岐を追加